### PR TITLE
Update categorytree.php

### DIFF
--- a/categorytree.php
+++ b/categorytree.php
@@ -18,7 +18,7 @@ class CategoryTree
 
     private function &findCategory(array &$children, string $category): array {
         if (array_key_exists($category, $children)) return $children[$category];
-        foreach($children as $child) {
+        foreach($children as &$child) {
             $founCategory=&$this->findCategory($child, $category);
             if (!is_null($founCategory)) return $founCategory;
         }


### PR DESCRIPTION
Corrige funcion findCategory ya que al operar con foreach el elemento de la iteracion era una copia y no una referencia, asi al encontrar la categoria padre, se devuelve una referencia a sus hijos (y no una copia como estaba originalmente).